### PR TITLE
Added option to force use24hFormat to showCupertinoTimePicker

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,7 @@ class _ExampleAppState extends State<ExampleApp> {
   }
 
   /// The context comes from the `Builder` above the widget tree.
-  Future<TimeOfDay?> onTimeWidgetTap(BuildContext context) async {
+  Future<TimeOfDay?> onTimeWidgetTap(BuildContext context, [bool? use24hFormat]) async {
     final RenderBox? renderBox = context.findRenderObject() as RenderBox?;
 
     return showCupertinoTimePicker(
@@ -56,6 +56,7 @@ class _ExampleAppState extends State<ExampleApp> {
       widgetRenderBox: renderBox,
       initialTime: _selectedTime,
       onTimeChanged: _onTimeChanged,
+      use24hFormat: use24hFormat,
     );
   }
 
@@ -134,6 +135,25 @@ class _ExampleAppState extends State<ExampleApp> {
                   onTap: (context) => onTimeWidgetTap(context),
                   title: 'My time widget',
                 ),
+              ],
+            ),
+            const SizedBox(height: 15),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _MyWidget(
+                  /// Passing exactly this `BuildContext` is mandatory to get
+                  /// the `RenderBox` of the appropriate widget.
+                  onTap: (context) => onTimeWidgetTap(context, true),
+                  title: 'Time widget 24h on',
+                ),
+                const SizedBox(width: 10),
+                _MyWidget(
+                  /// Passing exactly this `BuildContext` is mandatory to get
+                  /// the `RenderBox` of the appropriate widget.
+                  onTap: (context) => onTimeWidgetTap(context, false),
+                  title: 'Time widget 24h off',
+                )
               ],
             ),
             const Spacer(flex: 3),

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -247,6 +247,12 @@ Future<DateTime?> showCupertinoCalendarPicker(
 /// - [minuteInterval]:
 ///   The interval of minutes that the time picker should allow.
 ///   The default value is 1 minute, meaning the user can select any minute of the hour.
+/// 
+/// - [use24hFormat]:
+///   For 24h format being used or not, results in AM/PM being shown or hidden in the widget.
+///   Setting to true or false will force 24h format to be on or off.
+///   Can be used as a type of duration picker (limited to 23 hours) when set to true.
+///   The default value is null, which calls [MediaQuery.alwaysUse24HourFormatOf].
 ///
 /// ## Returns:
 ///
@@ -266,6 +272,7 @@ Future<TimeOfDay?> showCupertinoTimePicker(
   Color barrierColor = Colors.transparent,
   PickerContainerDecoration? containerDecoration,
   int minuteInterval = 1,
+  bool? use24hFormat,
 }) {
   return showGeneralDialog<TimeOfDay?>(
     context: context,
@@ -297,6 +304,7 @@ Future<TimeOfDay?> showCupertinoTimePicker(
         containerDecoration: containerDecoration,
         onTimeChanged: onTimeChanged,
         minuteInterval: minuteInterval,
+        use24hFormat: use24hFormat
       );
     },
   );

--- a/lib/src/time/cupertino_time_picker.dart
+++ b/lib/src/time/cupertino_time_picker.dart
@@ -12,6 +12,7 @@ class CupertinoTimePicker extends StatelessWidget {
     required this.maximumTime,
     required this.onTimeChanged,
     required this.minuteInterval,
+    this.use24hFormat,
     super.key,
   });
 
@@ -20,6 +21,7 @@ class CupertinoTimePicker extends StatelessWidget {
   final TimeOfDay maximumTime;
   final ValueChanged<DateTime> onTimeChanged;
   final int minuteInterval;
+  final bool? use24hFormat;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +36,7 @@ class CupertinoTimePicker extends StatelessWidget {
             maximumDateTime: maximumTime.toNowDateTime(),
             onTimeChanged: onTimeChanged,
             minuteInterval: minuteInterval,
+            use24hFormat: use24hFormat,
           ),
         ),
       ),

--- a/lib/src/time/cupertino_time_picker_wheel.dart
+++ b/lib/src/time/cupertino_time_picker_wheel.dart
@@ -12,6 +12,7 @@ class CupertinoTimePickerWheel extends StatelessWidget {
     required this.maximumDateTime,
     required this.onTimeChanged,
     required this.minuteInterval,
+    this.use24hFormat,
     this.pickerKey,
     super.key,
   });
@@ -22,6 +23,7 @@ class CupertinoTimePickerWheel extends StatelessWidget {
   final DateTime maximumDateTime;
   final ValueChanged<DateTime> onTimeChanged;
   final int minuteInterval;
+  final bool? use24hFormat;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +34,7 @@ class CupertinoTimePickerWheel extends StatelessWidget {
       minimumDate: minimumDateTime,
       maximumDate: maximumDateTime,
       onDateTimeChanged: onTimeChanged,
-      use24hFormat: MediaQuery.alwaysUse24HourFormatOf(context),
+      use24hFormat: use24hFormat ?? MediaQuery.alwaysUse24HourFormatOf(context),
       minuteInterval: minuteInterval,
     );
   }

--- a/lib/src/time/overlay/cupertino_time_overlay.dart
+++ b/lib/src/time/overlay/cupertino_time_overlay.dart
@@ -12,6 +12,7 @@ class CupertinoTimeOverlay extends StatefulWidget {
     required this.verticalSpacing,
     required this.offset,
     required this.minuteInterval,
+    this.use24hFormat,
     TimeOfDay? initialTime,
     TimeOfDay? minimumTime,
     TimeOfDay? maximumTime,
@@ -45,6 +46,7 @@ class CupertinoTimeOverlay extends StatefulWidget {
   final PickerContainerDecoration? containerDecoration;
   final ValueChanged<TimeOfDay>? onTimeChanged;
   final int minuteInterval;
+  final bool? use24hFormat;
 
   @override
   State<CupertinoTimeOverlay> createState() => _CupertinoTimeOverlayState();
@@ -89,6 +91,7 @@ class _CupertinoTimeOverlayState extends State<CupertinoTimeOverlay> {
         maximumTime: widget.maximumTime,
         onTimeChanged: _onDateTimeChanged,
         minuteInterval: widget.minuteInterval,
+        use24hFormat: widget.use24hFormat,
       ),
     );
   }


### PR DESCRIPTION
This is so that the time picker can double as a duration style picker (up to 23:59).

Relates to #11 

Example shows when the value is set to true (24h on) and false (24h off). Default value is null, which maintains current behaviour.

24h On
![24h On](https://github.com/user-attachments/assets/afea7855-80a6-4193-9f80-a5ac436d26d1)

24h Off
![24h Off](https://github.com/user-attachments/assets/453c6e42-126b-4b16-b1b7-ad4aee4920b0)
