### PR TITLE
Fix/am pm format error

### DIFF
--- a/lib/src/calendar/footer/calendar_footer.dart
+++ b/lib/src/calendar/footer/calendar_footer.dart
@@ -140,15 +140,13 @@ class _CalendarFooterState extends State<CalendarFooter> {
                   return MapEntry<DayPeriod, Widget>(
                     period,
                     SizedBox(
-                      width: 30.0,
-                      height: 30.0,
+                      width: 32.0,
+                      height: 32.0,
                       child: Center(
                         child: Text(
                           period.localizedString(context),
                           textAlign: TextAlign.center,
-                          style: TextStyle(
-                            fontSize: 13.0,
-                            color: CupertinoColors.label.resolveFrom(context),
+                          style: widget.decoration.dayPeriodTextStyle?.copyWith(
                             fontWeight:
                                 isActive ? FontWeight.w600 : FontWeight.w400,
                           ),

--- a/lib/src/calendar/footer/calendar_footer.dart
+++ b/lib/src/calendar/footer/calendar_footer.dart
@@ -140,8 +140,8 @@ class _CalendarFooterState extends State<CalendarFooter> {
                   return MapEntry<DayPeriod, Widget>(
                     period,
                     SizedBox(
-                      width: 32.0,
-                      height: 32.0,
+                      width: 30.0,
+                      height: 30.0,
                       child: Center(
                         child: Text(
                           period.localizedString(context),

--- a/lib/src/calendar/footer/calendar_footer.dart
+++ b/lib/src/calendar/footer/calendar_footer.dart
@@ -61,9 +61,10 @@ class _CalendarFooterState extends State<CalendarFooter> {
   void _onDayPeriodChanged(DayPeriod? dayPeriod) {
     if (dayPeriod != null) {
       setState(() {
-        final int newHour = dayPeriod == DayPeriod.pm ? 12 : -12;
+        final int newHour =
+            _timeOfDay.hour % 12 + (dayPeriod == DayPeriod.pm ? 12 : 0);
         _timeOfDay = TimeOfDay(
-          hour: _timeOfDay.hour + newHour,
+          hour: newHour,
           minute: _timeOfDay.minute,
         );
         widget.onTimeChanged(_timeOfDay);

--- a/lib/src/calendar/footer/calendar_footer_decoration.dart
+++ b/lib/src/calendar/footer/calendar_footer_decoration.dart
@@ -14,6 +14,11 @@ const TextStyle calendarFooterTimeLabelStyle = TextStyle(
   color: calendarFooterTitleColor,
   fontSize: 17.0,
 );
+const TextStyle calendarDayPeriodTextStyle = TextStyle(
+  // Nuevo estilo base
+  fontSize: 13.0,
+  color: CupertinoColors.label,
+);
 
 /// A decoration class for the calendar's footer.
 class CalendarFooterDecoration {
@@ -22,16 +27,19 @@ class CalendarFooterDecoration {
   factory CalendarFooterDecoration({
     TextStyle? timeLabelStyle,
     TextStyle? timeStyle,
+    TextStyle? dayPeriodTextStyle,
   }) {
     return CalendarFooterDecoration._(
       timeLabelStyle: timeLabelStyle ?? calendarFooterTimeLabelStyle,
       timeStyle: timeStyle ?? calendarTimeStyle,
+      dayPeriodTextStyle: dayPeriodTextStyle ?? calendarDayPeriodTextStyle,
     );
   }
 
   const CalendarFooterDecoration._({
     this.timeLabelStyle,
     this.timeStyle,
+    this.dayPeriodTextStyle,
   });
 
   /// Creates a calendar's footer decoration class with default values
@@ -42,10 +50,14 @@ class CalendarFooterDecoration {
     BuildContext context, {
     TextStyle? timeLabelStyle,
     TextStyle? timeStyle,
+    TextStyle? dayPeriodTextStyle,
   }) {
     final TextStyle timeTextStyle = timeStyle ?? calendarFooterTimeLabelStyle;
     final TextStyle titleTextStyle =
         timeLabelStyle ?? calendarFooterTimeLabelStyle;
+    final TextStyle periodTextStyle =
+        dayPeriodTextStyle ?? calendarDayPeriodTextStyle;
+
     return CalendarFooterDecoration(
       timeLabelStyle: titleTextStyle.copyWith(
         color: CupertinoDynamicColor.resolve(
@@ -59,6 +71,12 @@ class CalendarFooterDecoration {
           context,
         ),
       ),
+      dayPeriodTextStyle: periodTextStyle.copyWith(
+        color: CupertinoDynamicColor.resolve(
+          periodTextStyle.color ?? CupertinoColors.label,
+          context,
+        ),
+      ),
     );
   }
 
@@ -68,14 +86,19 @@ class CalendarFooterDecoration {
   /// The [TextStyle] of the calendar's time.
   final TextStyle? timeStyle;
 
+  /// The [TextStyle] of the AM/PM switcher text. // Nuevo campo
+  final TextStyle? dayPeriodTextStyle;
+
   /// Creates a copy of the class with the provided parameters.
   CalendarFooterDecoration copyWith({
     TextStyle? timeLabelStyle,
     TextStyle? timeStyle,
+    TextStyle? dayPeriodTextStyle,
   }) {
     return CalendarFooterDecoration(
       timeLabelStyle: timeLabelStyle ?? this.timeLabelStyle,
       timeStyle: timeStyle ?? this.timeStyle,
+      dayPeriodTextStyle: dayPeriodTextStyle ?? this.dayPeriodTextStyle,
     );
   }
 }

--- a/lib/src/calendar/footer/calendar_footer_decoration.dart
+++ b/lib/src/calendar/footer/calendar_footer_decoration.dart
@@ -15,7 +15,6 @@ const TextStyle calendarFooterTimeLabelStyle = TextStyle(
   fontSize: 17.0,
 );
 const TextStyle calendarDayPeriodTextStyle = TextStyle(
-  // Nuevo estilo base
   fontSize: 13.0,
   color: CupertinoColors.label,
 );
@@ -86,7 +85,7 @@ class CalendarFooterDecoration {
   /// The [TextStyle] of the calendar's time.
   final TextStyle? timeStyle;
 
-  /// The [TextStyle] of the AM/PM switcher text. // Nuevo campo
+  /// The [TextStyle] of the AM/PM switcher text.
   final TextStyle? dayPeriodTextStyle;
 
   /// Creates a copy of the class with the provided parameters.

--- a/lib/src/extensions/time_of_day_extension.dart
+++ b/lib/src/extensions/time_of_day_extension.dart
@@ -36,10 +36,7 @@ extension TimeOfDayExtension on TimeOfDay {
   }
 
   String timeWithDayPeriodFormat(BuildContext context) {
-    const String formatString = DateFormat.HOUR_MINUTE;
-    final String formattedTime = DateFormat(formatString).format(toDateTime());
-    final int spaceIndex = formattedTime.indexOf(' ');
-    return formattedTime.replaceRange(spaceIndex, null, '');
+    return DateFormat('h:mm').format(toDateTime());
   }
 
   String timeFormat(
@@ -47,8 +44,7 @@ extension TimeOfDayExtension on TimeOfDay {
     required bool? use24hFormat,
   }) {
     final bool use24HoursFormat = use24hFormat ?? context.alwaysUse24hFormat;
-    final String timeFormatString =
-        use24HoursFormat ? DateFormat.HOUR24_MINUTE : DateFormat.HOUR_MINUTE;
-    return DateFormat(timeFormatString).format(toDateTime());
+    final String pattern = use24HoursFormat ? 'HH:mm' : 'h:mm a';
+    return DateFormat(pattern).format(toDateTime());
   }
 }


### PR DESCRIPTION
## Description
- **Error:** `RangeError` when formatting hours in languages without spaces (e.g., Spanish).
- ** Solution:** 
  - Use explicit patterns (`h:mm a` and `HH:mm`) to avoid dependency on spaces.
  - Fix the AM/PM conversion logic.
  - Add customization for the AM/PM text style.

![Simulator Screenshot - iPhone 16 Pro Max - 2025-01-23 at 19 13 28](https://github.com/user-attachments/assets/189001a4-d7da-4429-a04e-e5f1cca7345e)

