### PR TITLE
Restrict intl dependency version to >=0.19.0 <0.21.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.19.0
+  intl: any
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: any
+  intl: ">=0.19.0 <0.21.0"
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
With `intl: ^0.19.0`, `pub get` will fail in the next Flutter version.

Could you consider setting the intl version to `any`?

```log
Resolving dependencies... 
Note: intl is pinned to version 0.20.2 by flutter_localizations from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of cupertino_calendar_picker depends on flutter_localizations from sdk which depends on intl 0.20.2, every version of cupertino_calendar_picker requires intl 0.20.2.
So, because blooms depends on cupertino_calendar_picker ^2.2.0 which depends on intl ^0.19.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on cupertino_calendar_picker: dart pub add cupertino_calendar_picker:^2.0.1
```

```log
Flutter 3.30.0-0.1.pre • channel beta • https://github.com/flutter/flutter.git
Framework • revision 360a12c848 (6 days ago) • 2025-02-14 13:36:09 -0800
Engine • revision 29a2f674ca
Tools • Dart 3.8.0 (build 3.8.0-70.0.dev) • DevTools 2.43.0
```
