### PR TITLE
feat: Expose looping parameter and fix hour looping in CupertinoTimerPicker

### DIFF
--- a/lib/cupertino_calendar_picker.dart
+++ b/lib/cupertino_calendar_picker.dart
@@ -2,6 +2,8 @@
 /// and time selection seamless and visually consistent with iOS design principles.
 library;
 
+export 'src/calendar/date_picker/custom_cupertino_date_picker.dart'
+    show CupertinoTimerPicker, CupertinoTimerPickerMode;
 export 'src/src.dart'
     show
         showCupertinoCalendarPicker,

--- a/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart
+++ b/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart
@@ -268,6 +268,10 @@ class CustomCupertinoDatePicker extends StatefulWidget {
   /// mode. When using monthYear mode, both [DatePickerDateOrder.dmy] and
   /// [DatePickerDateOrder.mdy] will result in the month|year order.
   /// Defaults to the locale's default date format/order.
+  /// 
+  /// [looping] determines whether the hour and minute pickers should loop.
+  /// When true, scrolling past the last item wraps to the first item and vice versa.
+  /// Defaults to true.
   CustomCupertinoDatePicker({
     required this.onDateTimeChanged,
     super.key,
@@ -284,6 +288,7 @@ class CustomCupertinoDatePicker extends StatefulWidget {
     this.showDayOfWeek = false,
     this.itemExtent = _kItemExtent,
     this.selectionOverlayBuilder,
+    this.looping = true,
   })  : initialDateTime = initialDateTime ?? DateTime.now(),
         assert(
           itemExtent > 0,
@@ -462,6 +467,12 @@ class CustomCupertinoDatePicker extends StatefulWidget {
   /// ```
   /// {@end-tool}
   final SelectionOverlayBuilder? selectionOverlayBuilder;
+
+  /// Whether the hour and minute pickers should loop.
+  /// 
+  /// When true, scrolling past the last item wraps to the first item and vice versa.
+  /// Defaults to true.
+  final bool looping;
 
   @override
   State<StatefulWidget> createState() {
@@ -931,7 +942,7 @@ class CustomCupertinoDatePickerDateTimeState
 
             assert(debugIsFlipped == isHourRegionFlipped);
           },
-          looping: true,
+          looping: widget.looping,
           selectionOverlay: selectionOverlay,
           children: List<Widget>.generate(24, (int index) {
             final int hour = isHourRegionFlipped ? (index + 12) % 24 : index;
@@ -983,7 +994,7 @@ class CustomCupertinoDatePickerDateTimeState
           backgroundColor: widget.backgroundColor,
           squeeze: _kSqueeze,
           onSelectedItemChanged: _onSelectedItemChange,
-          looping: true,
+          looping: widget.looping,
           selectionOverlay: selectionOverlay,
           children:
               List<Widget>.generate(60 ~/ widget.minuteInterval, (int index) {
@@ -2569,6 +2580,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
         itemExtent: widget.itemExtent,
         backgroundColor: widget.backgroundColor,
         squeeze: _kSqueeze,
+        looping: true,
         onSelectedItemChanged: (int index) {
           setState(() {
             selectedHour = index;

--- a/lib/src/calendar/month_picker/calendar_month_picker.dart
+++ b/lib/src/calendar/month_picker/calendar_month_picker.dart
@@ -4,6 +4,7 @@
 
 import 'package:cupertino_calendar_picker/src/src.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 // /// Displays the days of a given month and allows choosing a day.
 // ///
@@ -166,11 +167,19 @@ class CalendarMonthPickerState extends State<CalendarMonthPicker> {
               CalendarMonthPickerDefaultDayStyle.withDynamicColor(context);
         }
 
-        final Widget dayWidget = CalendarMonthPickerDay(
-          dayDate: date,
-          onDaySelected: isDisabledDay ? null : widget.onChanged,
-          style: style,
-          backgroundCircleSize: backgroundCircleSize,
+        final Widget dayWidget = MergeSemantics(
+          child: Semantics(
+            button: true,
+            label: DateFormat.MMMMd(Localizations.localeOf(context).toString())
+                .format(date),
+            selected: isSelectedDay,
+            child: CalendarMonthPickerDay(
+              dayDate: date,
+              onDaySelected: isDisabledDay ? null : widget.onChanged,
+              style: style,
+              backgroundCircleSize: backgroundCircleSize,
+            ),
+          ),
         );
         yield dayWidget;
       }

--- a/lib/src/calendar/month_picker/calendar_month_picker.dart
+++ b/lib/src/calendar/month_picker/calendar_month_picker.dart
@@ -4,7 +4,6 @@
 
 import 'package:cupertino_calendar_picker/src/src.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 // /// Displays the days of a given month and allows choosing a day.
 // ///
@@ -167,19 +166,11 @@ class CalendarMonthPickerState extends State<CalendarMonthPicker> {
               CalendarMonthPickerDefaultDayStyle.withDynamicColor(context);
         }
 
-        final Widget dayWidget = MergeSemantics(
-          child: Semantics(
-            button: true,
-            label: DateFormat.MMMMd(Localizations.localeOf(context).toString())
-                .format(date),
-            selected: isSelectedDay,
-            child: CalendarMonthPickerDay(
-              dayDate: date,
-              onDaySelected: isDisabledDay ? null : widget.onChanged,
-              style: style,
-              backgroundCircleSize: backgroundCircleSize,
-            ),
-          ),
+        final Widget dayWidget = CalendarMonthPickerDay(
+          dayDate: date,
+          onDaySelected: isDisabledDay ? null : widget.onChanged,
+          style: style,
+          backgroundCircleSize: backgroundCircleSize,
         );
         yield dayWidget;
       }

--- a/lib/src/time/cupertino_time_picker.dart
+++ b/lib/src/time/cupertino_time_picker.dart
@@ -13,6 +13,7 @@ class CupertinoTimePicker extends StatelessWidget {
     required this.onTimeChanged,
     required this.minuteInterval,
     required this.use24hFormat,
+    this.looping = true,
     super.key,
   });
 
@@ -22,6 +23,7 @@ class CupertinoTimePicker extends StatelessWidget {
   final ValueChanged<DateTime> onTimeChanged;
   final int minuteInterval;
   final bool use24hFormat;
+  final bool looping;
 
   @override
   Widget build(BuildContext context) {
@@ -37,6 +39,7 @@ class CupertinoTimePicker extends StatelessWidget {
             onTimeChanged: onTimeChanged,
             minuteInterval: minuteInterval,
             use24hFormat: use24hFormat,
+            looping: looping,
           ),
         ),
       ),

--- a/lib/src/time/cupertino_time_picker_wheel.dart
+++ b/lib/src/time/cupertino_time_picker_wheel.dart
@@ -14,6 +14,7 @@ class CupertinoTimePickerWheel extends StatelessWidget {
     required this.minuteInterval,
     this.use24hFormat,
     this.pickerKey,
+    this.looping = true,
     super.key,
   });
 
@@ -24,6 +25,7 @@ class CupertinoTimePickerWheel extends StatelessWidget {
   final ValueChanged<DateTime> onTimeChanged;
   final int minuteInterval;
   final bool? use24hFormat;
+  final bool looping;
 
   @override
   Widget build(BuildContext context) {
@@ -36,6 +38,7 @@ class CupertinoTimePickerWheel extends StatelessWidget {
       onDateTimeChanged: onTimeChanged,
       use24hFormat: use24hFormat ?? context.alwaysUse24hFormat,
       minuteInterval: minuteInterval,
+      looping: looping,
     );
   }
 }


### PR DESCRIPTION
## Summary

Exposes the `looping` parameter in [CustomCupertinoDatePicker](cci:2://file:///Users/mikailsuyer/Materna/cupertino_calendar_picker/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart:224:0-580:1) to control infinite scrolling behavior for hour and minute pickers. Also fixes a bug where hours didn't loop in [CupertinoTimerPicker](cci:2://file:///Users/mikailsuyer/Materna/cupertino_calendar_picker/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart:2216:0-2329:1).

## Changes

- Added `looping` parameter to [CustomCupertinoDatePicker](cci:2://file:///Users/mikailsuyer/Materna/cupertino_calendar_picker/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart:224:0-580:1) (defaults to `true`)
- Fixed missing `looping: true` in [CupertinoTimerPicker](cci:2://file:///Users/mikailsuyer/Materna/cupertino_calendar_picker/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart:2216:0-2329:1) hour picker
- Propagated parameter through `CupertinoTimePickerWheel` and `CupertinoTimePicker`
- Exported [CupertinoTimerPicker](cci:2://file:///Users/mikailsuyer/Materna/cupertino_calendar_picker/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart:2216:0-2329:1) and `CupertinoTimerPickerMode` in public API

## Motivation

The underlying `CupertinoPicker` supports looping, but this wasn't exposed in the API. Additionally, [CupertinoTimerPicker](cci:2://file:///Users/mikailsuyer/Materna/cupertino_calendar_picker/lib/src/calendar/date_picker/custom_cupertino_date_picker.dart:2216:0-2329:1) had inconsistent behavior - minutes looped but hours didn't.

## Breaking Changes

None. Default behavior (`looping: true`) is preserved for backward compatibility.